### PR TITLE
Exposed download status of the map

### DIFF
--- a/src/JeffWilcox.Maps/JeffWilcox.Maps.csproj
+++ b/src/JeffWilcox.Maps/JeffWilcox.Maps.csproj
@@ -62,6 +62,8 @@
     <Compile Include="StaticMapProvider.cs" />
     <Compile Include="StaticMapProviderType.cs" />
     <Compile Include="StaticMapQuestProvider.cs" />
+    <Compile Include="StaticMapStatus.cs" />
+    <Compile Include="StaticMapStatusChangedEventArgs.cs" />
     <Compile Include="StaticNokiaMapsProvider.cs" />
     <Compile Include="StaticOpenStreetMapProvider.cs" />
   </ItemGroup>

--- a/src/JeffWilcox.Maps/StaticMapStatus.cs
+++ b/src/JeffWilcox.Maps/StaticMapStatus.cs
@@ -1,0 +1,51 @@
+﻿//
+// Copyright (c) 2012 Jeff Wilcox
+// Parts of this class by Brice Clocher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace JeffWilcox.Controls
+{
+    /// <summary>
+    /// Represents the status of download of the static map.
+    /// </summary>
+    public enum StaticMapStatus
+    {
+        /// <summary>
+        /// The map is not initialized yet, and no download has been started.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The map image is being downloaded.
+        /// </summary>
+        Downloading,
+
+        /// <summary>
+        /// The map image failed to be downloaded.
+        /// </summary>
+        Failed,
+
+        /// <summary>
+        /// The map image is downloaded and on-screen.
+        /// </summary>
+        Done
+    }
+}

--- a/src/JeffWilcox.Maps/StaticMapStatusChangedEventArgs.cs
+++ b/src/JeffWilcox.Maps/StaticMapStatusChangedEventArgs.cs
@@ -1,0 +1,46 @@
+﻿//
+// Copyright (c) 2012 Jeff Wilcox
+// Parts of this class by Brice Clocher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace JeffWilcox.Controls
+{
+    public class StaticMapStatusChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the new status of the static map.
+        /// </summary>
+        public StaticMapStatus Status { get; private set; }
+
+        /// <summary>
+        /// Gets the exception that is associated to a <code>Failed</code> status.
+        /// </summary>
+        /// <value><code>null</code> if <paramref name="Status"/> is not <code>Failed</code>, an exception
+        /// object otherwise.</value>
+        public Exception ErrorException { get; private set; }
+
+        public StaticMapStatusChangedEventArgs(StaticMapStatus newStatus, Exception exception = null)
+        {
+            Status = newStatus;
+            ErrorException = newStatus == StaticMapStatus.Failed ? exception : null;
+        }
+        
+    }
+}


### PR DESCRIPTION
StaticMap.Status and StaticMap.StatusChanged can now be used to
determine if the map was succesfully downloaded or not.
Allows users to solve #7 at will.
